### PR TITLE
include hover library a different way [0.2.3-alpha]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-n/a
+### Updated
+
+Debbuging WIP...
 
 
-## [0.2.2] 2023-10-31
+## ~~[0.2.2]~~ 2023-10-31
+
+🐛 This version is buggy — avoid it.
+[#1](https://github.com/kglw-dot-net/discourse-plugin-gizzard-setlist/issues/1)
 
 ### Updated
 

--- a/assets/javascripts/discourse-markdown/kglw-setlist.js
+++ b/assets/javascripts/discourse-markdown/kglw-setlist.js
@@ -1,21 +1,23 @@
 // https://meta.discourse.org/t/developers-guide-to-markdown-extensions/66023#the-setup-protocol-3
+// https://github.com/discourse/discourse/blob/f8964f8f8ff1e386c50f22c804691191f546e9f8/app/assets/javascripts/discourse-markdown-it/src/features/bbcode-inline.js#L152
 export function setup(helper) {
   if (!helper.markdownIt)
     return;
 
-  // helper.registerOptions((opts,siteSettings)=>{ // TODO is this needed?
-  //   opts.features.['kglwSetlist'] = !!siteSettings.kglwSetlist_enabled;
-  // });
+  helper.registerOptions((opts, siteSettings) => {
+    opts['kglwSetlist'] = !!siteSettings.kglwSetlist_enabled; // field name matches setting name in plugin.rb
+  });
 
-  helper.allowList(['span.kglwSetlist']);
+  helper.allowList([
+    'span.kglwSetlist'
+  ]);
 
   helper.registerPlugin(md => {
+    // Adding a single _inline_ rule only.
+    // examples: https://github.com/discourse/discourse/blob/f8964f8f8ff1/app/assets/javascripts/discourse-markdown-it/src/features/bbcode-inline.js#L303-L322
     md.inline.bbcode.ruler.push('setlist', {
       tag: 'setlist',
       wrap: 'span.kglwSetlist'
     });
-  //   md.inline.push('setlist', (state, silent) => {
-  //     
-  //   });
   });
 }

--- a/assets/javascripts/discourse/initializers/setlist.js
+++ b/assets/javascripts/discourse/initializers/setlist.js
@@ -1,5 +1,4 @@
-import tippy from 'https://unpkg.com/tippy.js@6'; // WIP...
-
+import loadScript from 'discourse/lib/load-script';
 import { withPluginApi } from 'discourse/lib/plugin-api';
 import ComposerController from 'discourse/controllers/composer';
 import { addBlockDecorateCallback, addTagDecorateCallback } from 'discourse/lib/to-markdown';
@@ -52,7 +51,8 @@ async function buildInteractiveSetlistComponent(setlistElement) {
       if (tracksArr) return setlistStr + `<br/><b>${whichSet === 'e' ? 'Encore' : `Set ${whichSet}`}:</b> ` + tracksArr.join('');
       return setlistStr;
     }, '')
-    tippy(setlistElement, {
+    await loadScript('https://unpkg.com/tippy.js@6');
+    window.tippy && window.tippy(setlistElement, {
       content: `<a href="https://kglw.net/setlists/${permalink}" target="_blank" rel="noopener">${showdate} @ ${venuename} (${city}, ${state || country})</a>${setlist}`,
       placement: 'top-start',
       duration: 0,

--- a/plugin.rb
+++ b/plugin.rb
@@ -4,5 +4,5 @@
 # authors: KGLW.net, Axe <alxndr+kglw-setlist-plugin@gmail.com>
 # url: https://github.com/kglw-dot-net/discourse-plugin-gizzard-setlist
 
-enabled_site_setting :kglwSetlist_enabled
+enabled_site_setting :kglwSetlist_enabled # setting name matches field in kglw-setlist.js
 register_asset 'stylesheets/discourse_kglwSetlist.scss'

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,6 +1,6 @@
 # name: discourse-plugin-gizzard-setlist
 # about: Turn a [setlist] code into a King Gizz setlist: `[setlist]2022-10-02[/setlist]` use `#2` to specify second show on same date `[setlist]2023-06-08#2[/setlist]`
-# version: 0.2.2
+# version: 0.2.3-alpha
 # authors: KGLW.net, Axe <alxndr+kglw-setlist-plugin@gmail.com>
 # url: https://github.com/kglw-dot-net/discourse-plugin-gizzard-setlist
 


### PR DESCRIPTION
I suspect Tippy was being included by another plugin which eventually jettisoned it (or it/Discourse changed how module resolution works)...

<img width="588" alt="Screenshot 2024-03-13 at 5 23 57 PM" src="https://github.com/kglw-dot-net/discourse-plugin-gizzard-setlist/assets/174307/8d6ae2a6-1ee9-44fa-a7fd-b6c5cc0dfa59">

---

May address:
* #1 
* #4 