### PR TITLE
remove `addToolbarPopupMenuOptionsCallback` call  [0.2.3-alpha4]

### DIFF
--- a/assets/javascripts/discourse/initializers/setlist.js
+++ b/assets/javascripts/discourse/initializers/setlist.js
@@ -81,15 +81,10 @@ async function buildInteractiveSetlistComponent(setlistElement) {
 }
 
 export function initializeSetlistCode(api) {
-  // add button to Editing Content menu (...?) e.g. when you highlight a word in the Discourse editor
-  api.addToolbarPopupMenuOptionsCallback(() => ({
-    action: 'insertSetlist',
-    icon: 'list',
-    label: 'setlist.title'
-  }));
+  // add button to toolbar above the editing toolbar (editor button bar)
   ComposerController.reopen({
     actions: {
-      insertSetlist() { // matches action prop passed to addToolbarPopupMenuOptionsCallback
+      insertSetlist() {
         this.get('toolbarEvent').applySurround(
           '[setlist]',
           '[/setlist]',

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,6 +1,6 @@
 # name: gizzard-setlist
 # about: Turn a [setlist] code into a King Gizz setlist popup.
-# version: 0.2.3-alpha3
+# version: 0.2.3-alpha4
 # authors: Axe <alxndr+kglw-setlist-plugin@gmail.com> & KGLW.net
 # url: https://github.com/kglw-dot-net/discourse-plugin-gizzard-setlist
 


### PR DESCRIPTION
Think this was detritus from initial exploration

[#1]